### PR TITLE
Fix camera widget to run correctly

### DIFF
--- a/ADA/WIDGETS/camera.py
+++ b/ADA/WIDGETS/camera.py
@@ -3,8 +3,6 @@ import cv2
 def open():
     """Opens the default camera using OpenCV and displays the video feed. Press 'q' to exit."""
 
-    return "Camera is open"
-
     global cap  # Access the global cap variable
     cap = cv2.VideoCapture(0)
 
@@ -22,3 +20,7 @@ def open():
 
         if cv2.waitKey(1) & 0xFF == ord('q'):
             break
+
+    cap.release()
+    cv2.destroyAllWindows()
+    return "Camera closed"


### PR DESCRIPTION
## Summary
- fix camera.open by deleting early return
- clean up camera after loop and return status string

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'ollama', 'RealtimeTTS')*

------
https://chatgpt.com/codex/tasks/task_e_6863c279769c832ab3238186db701689