### PR TITLE
Fix docstring filename reference

### DIFF
--- a/multimodal_live_api.py
+++ b/multimodal_live_api.py
@@ -19,14 +19,14 @@ the model from interrupting itself it is important that you use headphones.
 To run the script:
 
 ```
-python Get_started_LiveAPI.py
+python multimodal_live_api.py
 ```
 
 The script takes a video-mode flag `--mode`, this can be "camera", "screen", or "none".
 The default is "camera". To share your screen run:
 
 ```
-python Get_started_LiveAPI.py --mode screen
+python multimodal_live_api.py --mode screen
 ```
 """
 


### PR DESCRIPTION
## Summary
- update getting started docstring in `multimodal_live_api.py` to refer to the correct file name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6863c280598c832ab8d536ba7f9a6e7b