### PR TITLE
Add simple Home Assistant integration

### DIFF
--- a/ADA/ADA_Local.py
+++ b/ADA/ADA_Local.py
@@ -7,7 +7,7 @@ import torch  # Import the torch library
 import re
 import time
 import os
-from .WIDGETS import system, timer, project, camera
+from .WIDGETS import system, timer, project, camera, home_automation
 
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
 VOICE_ID = 'pFZP5JQG7iQjIQuC4Bku'
@@ -67,6 +67,14 @@ class ADA:
                 Args:
                     folder_name (str): The name of the project folder to create.
                 """
+            def home_automation.ac_power(state: str):
+                """Turn the AC on or off."""
+
+            def home_automation.light_power(state: str):
+                """Turn a light on or off."""
+
+            def home_automation.tv_power(state: str):
+                """Turn the TV on or off."""
         ```
 
         User: {user_message}

--- a/ADA/ADA_Online.py
+++ b/ADA/ADA_Online.py
@@ -15,6 +15,7 @@ import python_weather
 import googlemaps # Added for travel duration
 from datetime import datetime # Added for travel duration
 from dotenv import load_dotenv # Added for API key loading
+from .WIDGETS import home_automation
 
 # --- Load Environment Variables ---
 load_dotenv()
@@ -80,12 +81,42 @@ class ADA:
                 }, required=["origin", "destination"]
             )
         )
+        self.ac_power_func = types.FunctionDeclaration(
+            name="ac_power",
+            description="Turn the AC on or off via home automation.",
+            parameters=types.Schema(
+                type=types.Type.OBJECT,
+                properties={"state": types.Schema(type=types.Type.STRING, description="on or off")},
+                required=["state"]
+            )
+        )
+        self.light_power_func = types.FunctionDeclaration(
+            name="light_power",
+            description="Turn a light on or off via home automation.",
+            parameters=types.Schema(
+                type=types.Type.OBJECT,
+                properties={"state": types.Schema(type=types.Type.STRING, description="on or off")},
+                required=["state"]
+            )
+        )
+        self.tv_power_func = types.FunctionDeclaration(
+            name="tv_power",
+            description="Turn the TV on or off via home automation.",
+            parameters=types.Schema(
+                type=types.Type.OBJECT,
+                properties={"state": types.Schema(type=types.Type.STRING, description="on or off")},
+                required=["state"]
+            )
+        )
         # --- End Function Declarations ---
 
         # --- Map function names to actual methods (Added get_travel_duration) ---
         self.available_functions = {
             "get_weather": self.get_weather,
-            "get_travel_duration": self.get_travel_duration # Added mapping
+            "get_travel_duration": self.get_travel_duration,
+            "ac_power": self.ac_power,
+            "light_power": self.light_power,
+            "tv_power": self.tv_power
         }
 
         # --- Google Search Tool (Grounding) ---
@@ -102,7 +133,10 @@ class ADA:
             # ---> Updated tools list <---
             tools=[self.google_search_tool, types.Tool(code_execution=types.ToolCodeExecution,function_declarations=[
                 self.get_weather_func,
-                self.get_travel_duration_func # Add the new function here
+                self.get_travel_duration_func,
+                self.ac_power_func,
+                self.light_power_func,
+                self.tv_power_func
                 ])]
         )
         # --- End Configuration ---
@@ -210,6 +244,21 @@ class ADA:
             print(f"Error calling _sync_get_travel_duration via to_thread: {e}")
             return {"duration_result": f"Failed to execute travel duration request: {e}"}
     # --- End Travel Duration Functions ---
+
+    async def ac_power(self, state: str) -> dict:
+        """Turn the AC on or off via home automation."""
+        result = await asyncio.to_thread(home_automation.ac_power, state)
+        return {"result": result}
+
+    async def light_power(self, state: str) -> dict:
+        """Turn a light on or off via home automation."""
+        result = await asyncio.to_thread(home_automation.light_power, state)
+        return {"result": result}
+
+    async def tv_power(self, state: str) -> dict:
+        """Turn the TV on or off via home automation."""
+        result = await asyncio.to_thread(home_automation.tv_power, state)
+        return {"result": result}
 
 
     async def clear_queues(self, text=""):

--- a/ADA/WIDGETS/home_automation.py
+++ b/ADA/WIDGETS/home_automation.py
@@ -1,0 +1,62 @@
+import os
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+HOME_ASSISTANT_URL = os.getenv("HOME_ASSISTANT_URL")
+HOME_ASSISTANT_TOKEN = os.getenv("HOME_ASSISTANT_TOKEN")
+
+AC_ENTITY_ID = os.getenv("AC_ENTITY_ID")
+LIGHT_ENTITY_ID = os.getenv("LIGHT_ENTITY_ID")
+TV_ENTITY_ID = os.getenv("TV_ENTITY_ID")
+
+
+def _call_service(domain: str, service: str, entity_id: str) -> str:
+    """Helper to call a Home Assistant service."""
+    if not HOME_ASSISTANT_URL or not HOME_ASSISTANT_TOKEN:
+        return "Home Assistant configuration missing."
+
+    url = f"{HOME_ASSISTANT_URL}/{domain}/{service}"
+    headers = {
+        "Authorization": f"Bearer {HOME_ASSISTANT_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    payload = {"entity_id": entity_id}
+
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=5)
+        response.raise_for_status()
+        return f"Sent {service} to {entity_id}."
+    except requests.RequestException as e:
+        return f"Error calling service: {e}"
+
+
+def ac_power(state: str) -> str:
+    """Turn the AC on or off."""
+    if not AC_ENTITY_ID:
+        return "AC entity ID not configured."
+    service = "turn_on" if state.lower() == "on" else "turn_off"
+    return _call_service("climate", service, AC_ENTITY_ID)
+
+
+def light_power(state: str) -> str:
+    """Turn a light on or off."""
+    if not LIGHT_ENTITY_ID:
+        return "Light entity ID not configured."
+    service = "turn_on" if state.lower() == "on" else "turn_off"
+    return _call_service("light", service, LIGHT_ENTITY_ID)
+
+
+def tv_power(state: str) -> str:
+    """Turn the TV on or off."""
+    if not TV_ENTITY_ID:
+        return "TV entity ID not configured."
+    service = "turn_on" if state.lower() == "on" else "turn_off"
+    return _call_service("media_player", service, TV_ENTITY_ID)
+
+
+if __name__ == "__main__":
+    print(ac_power("on"))
+    print(light_power("off"))
+    print(tv_power("on"))

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Both `ada_online` and `multimodal_live_api.py` require API keys for cloud servic
     GOOGLE_API_KEY=YOUR_GOOGLE_AI_STUDIO_KEY_HERE
     ELEVENLABS_API_KEY=YOUR_ELEVENLABS_KEY_HERE
     MAPS_API_KEY=YOUR_Maps_API_KEY_HERE
+    HOME_ASSISTANT_URL=http://localhost:8123/api/services
+    HOME_ASSISTANT_TOKEN=YOUR_LONG_LIVED_TOKEN
+    AC_ENTITY_ID=climate.your_ac
+    LIGHT_ENTITY_ID=light.living_room
+    TV_ENTITY_ID=media_player.living_room_tv
     ```
 
 3.  **Get the Keys:**
@@ -190,6 +195,7 @@ ADA (`ada_local` and `ada_online`) can utilize several built-in functions/tools:
   - `system.py`: Provides system hardware information.
   - `timer.py`: Sets countdown timers.
   - `to_do_list.py`: Manages a simple to-do list. (_Not integrated_)
+  - `home_automation.py`: Send on/off commands to smart devices via Home Assistant.
 - **Online Tools (Gemini API):** Used by `ada_online` versions.
   - `GoogleSearch`: Accesses Google Search for current information.
   - `get_weather`: Fetches weather using `python-weather`.


### PR DESCRIPTION
## Summary
- introduce `home_automation.py` widget with Home Assistant HTTP calls
- document environment variables for controlling AC, lights and TV
- make ADA_Local aware of home automation functions
- expose new home automation tools in ADA_Online

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for ollama and RealtimeTTS)*

------
https://chatgpt.com/codex/tasks/task_e_6863c76ab694832aa60cf750f5670087